### PR TITLE
current_setpoint->current_setpoint.data

### DIFF
--- a/autopilot_interface.cpp
+++ b/autopilot_interface.cpp
@@ -223,6 +223,7 @@ void
 Autopilot_Interface::
 update_setpoint(mavlink_set_position_target_local_ned_t setpoint)
 {
+	std::lock_guard<std::mutex> lock(current_setpoint.mutex);
 	current_setpoint.data = setpoint;
 }
 

--- a/autopilot_interface.cpp
+++ b/autopilot_interface.cpp
@@ -223,7 +223,7 @@ void
 Autopilot_Interface::
 update_setpoint(mavlink_set_position_target_local_ned_t setpoint)
 {
-	current_setpoint = setpoint;
+	current_setpoint.data = setpoint;
 }
 
 


### PR DESCRIPTION
# Fix error in autopilot_interface.cpp:226

> autopilot_interface.cpp: In member function ‘void Autopilot_Interface::update_setpoint(mavlink_set_position_target_local_ned_t)’:
autopilot_interface.cpp:226:21: error: no match for ‘operator=’ (operand types are ‘Autopilot_Interface::<unnamed struct>’ and ‘mavlink_set_position_target_local_ned_t {aka __mavlink_set_position_target_local_ned_t}’)
  current_setpoint = setpoint;

Change to:
`  current_setpoint.data = setpoint;`


![VirtualBox_Ubuntu_11_08_2020_12_42_13](https://user-images.githubusercontent.com/47026016/89885064-23987d80-dbd3-11ea-8405-ce722f71e790.png)

## Commit has been tested with
`make px4_sitl jmavsim
`
`./mavlink_control -u 127.0.0.1 
`
![VirtualBox_Ubuntu_11_08_2020_13_21_51](https://user-images.githubusercontent.com/47026016/89886656-a4f10f80-dbd5-11ea-94fe-2f26e25b9b2c.png)